### PR TITLE
Eng 669 fsgroup support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,8 @@
     <properties>
         <github.organization>entando-k8s</github.organization>
         <sonar.projectKey>${github.organization}_${project.artifactId}</sonar.projectKey>
-        <entando.k8s.operator.common.version>6.1.7</entando.k8s.operator.common.version>
-        <entando.k8s.custom.model.version>6.1.4</entando.k8s.custom.model.version>
+        <entando.k8s.operator.common.version>6.1.9</entando.k8s.operator.common.version>
+        <entando.k8s.custom.model.version>6.1.5</entando.k8s.custom.model.version>
         <preDeploymentTestGroups>in-process</preDeploymentTestGroups>
         <postDeploymentTestGroups>end-to-end</postDeploymentTestGroups>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <properties>
         <github.organization>entando-k8s</github.organization>
         <sonar.projectKey>${github.organization}_${project.artifactId}</sonar.projectKey>
-        <entando.k8s.operator.common.version>6.1.6</entando.k8s.operator.common.version>
+        <entando.k8s.operator.common.version>6.1.7</entando.k8s.operator.common.version>
         <entando.k8s.custom.model.version>6.1.4</entando.k8s.custom.model.version>
         <preDeploymentTestGroups>in-process</preDeploymentTestGroups>
         <postDeploymentTestGroups>end-to-end</postDeploymentTestGroups>

--- a/src/main/java/org/entando/kubernetes/controller/app/EntandoAppServerDeployable.java
+++ b/src/main/java/org/entando/kubernetes/controller/app/EntandoAppServerDeployable.java
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.extensions.Ingress;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import org.entando.kubernetes.controller.KeycloakConnectionConfig;
 import org.entando.kubernetes.controller.KubeUtils;
 import org.entando.kubernetes.controller.ServiceDeploymentResult;
@@ -31,6 +32,7 @@ import org.entando.kubernetes.controller.spi.DbAwareDeployable;
 import org.entando.kubernetes.controller.spi.DeployableContainer;
 import org.entando.kubernetes.controller.spi.PublicIngressingDeployable;
 import org.entando.kubernetes.model.DbmsVendor;
+import org.entando.kubernetes.model.JeeServer;
 import org.entando.kubernetes.model.app.EntandoApp;
 
 public class EntandoAppServerDeployable implements PublicIngressingDeployable<ServiceDeploymentResult>, DbAwareDeployable {
@@ -51,6 +53,22 @@ public class EntandoAppServerDeployable implements PublicIngressingDeployable<Se
                 new AppBuilderDeployableContainer(entandoApp)
         );
         this.keycloakConnectionConfig = keycloakConnectionConfig;
+    }
+
+    @Override
+    public Optional<Long> getFileSystemUserAndGroupId() {
+        return entandoApp.getSpec().getStandardServerImage().map(jeeServer -> {
+            switch (jeeServer){
+                case WILDFLY:
+                case JETTY:
+                    return 1001L;
+                case EAP:
+                    return 185L;
+                default:
+                    return null;
+            }
+        });
+
     }
 
     @Override

--- a/src/main/java/org/entando/kubernetes/controller/app/EntandoAppServerDeployable.java
+++ b/src/main/java/org/entando/kubernetes/controller/app/EntandoAppServerDeployable.java
@@ -36,7 +36,16 @@ import org.entando.kubernetes.model.JeeServer;
 import org.entando.kubernetes.model.app.EntandoApp;
 
 public class EntandoAppServerDeployable implements PublicIngressingDeployable<ServiceDeploymentResult>, DbAwareDeployable {
-
+    /**
+     * The operating system level id of the default user in the EAP base image. Was determined to be 185 running the
+     * 'id' command in the entando/entando-eap71-base image
+     * */
+    public static final long DEFAULT_USERID_IN_EAP_BASE_IMAGE = 185L;
+    /**
+     * The operating system level id of the default user in the wildfly base image. Was determined to be 1001 running the
+     * 'id' command in the entando/entando-wildfly12-base image
+     * */
+    public static final long DEFAULT_USERID_IN_WILDFLY_BASE_IMAGE = 1001L;
     private final EntandoApp entandoApp;
     private final List<DeployableContainer> containers;
     private final DatabaseServiceResult databaseServiceResult;
@@ -60,9 +69,9 @@ public class EntandoAppServerDeployable implements PublicIngressingDeployable<Se
         return entandoApp.getSpec().getStandardServerImage().map(jeeServer -> {
             switch (jeeServer) {
                 case EAP:
-                    return 185L;
+                    return DEFAULT_USERID_IN_EAP_BASE_IMAGE;
                 default:
-                    return 1001L;
+                    return DEFAULT_USERID_IN_WILDFLY_BASE_IMAGE;
             }
         });
 

--- a/src/main/java/org/entando/kubernetes/controller/app/EntandoAppServerDeployable.java
+++ b/src/main/java/org/entando/kubernetes/controller/app/EntandoAppServerDeployable.java
@@ -58,7 +58,7 @@ public class EntandoAppServerDeployable implements PublicIngressingDeployable<Se
     @Override
     public Optional<Long> getFileSystemUserAndGroupId() {
         return entandoApp.getSpec().getStandardServerImage().map(jeeServer -> {
-            switch (jeeServer){
+            switch (jeeServer) {
                 case EAP:
                     return 185L;
                 default:

--- a/src/main/java/org/entando/kubernetes/controller/app/EntandoAppServerDeployable.java
+++ b/src/main/java/org/entando/kubernetes/controller/app/EntandoAppServerDeployable.java
@@ -59,13 +59,10 @@ public class EntandoAppServerDeployable implements PublicIngressingDeployable<Se
     public Optional<Long> getFileSystemUserAndGroupId() {
         return entandoApp.getSpec().getStandardServerImage().map(jeeServer -> {
             switch (jeeServer){
-                case WILDFLY:
-                case JETTY:
-                    return 1001L;
                 case EAP:
                     return 185L;
                 default:
-                    return null;
+                    return 1001L;
             }
         });
 

--- a/src/test/java/org/entando/kubernetes/controller/app/inprocesstests/DeployEntandoServiceTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/app/inprocesstests/DeployEntandoServiceTest.java
@@ -54,9 +54,12 @@ import org.entando.kubernetes.controller.k8sclient.SimpleK8SClient;
 import org.entando.kubernetes.controller.test.support.FluentTraversals;
 import org.entando.kubernetes.controller.test.support.VariableReferenceAssertions;
 import org.entando.kubernetes.model.EntandoDeploymentPhase;
+import org.entando.kubernetes.model.JeeServer;
 import org.entando.kubernetes.model.app.EntandoApp;
+import org.entando.kubernetes.model.app.EntandoAppBuilder;
 import org.entando.kubernetes.model.infrastructure.EntandoClusterInfrastructure;
 import org.entando.kubernetes.model.keycloakserver.EntandoKeycloakServer;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -84,9 +87,8 @@ public class DeployEntandoServiceTest implements InProcessTestUtil, FluentTraver
     private static final String MY_APP_SERVER_DEPLOYMENT = MY_APP_SERVER + "-deployment";
     private static final String APPBUILDER_PORT = "appbuilder-port";
     private static final String MY_APP_DB_SERVICE = MY_APP + "-db-service";
-    private final EntandoApp entandoApp = newTestEntandoApp();
-    private final EntandoKeycloakServer keycloakServer = newEntandoKeycloakServer();
-    private final EntandoClusterInfrastructure entandoInfrastructure = newEntandoClusterInfrastructure();
+    private final EntandoApp entandoApp = new EntandoAppBuilder(newTestEntandoApp()).editSpec().withStandardServerImage(JeeServer.EAP)
+            .endSpec().build();
     @Spy
     private final SimpleK8SClient<EntandoResourceClientDouble> client = new SimpleK8SClientDouble();
 
@@ -104,12 +106,19 @@ public class DeployEntandoServiceTest implements InProcessTestUtil, FluentTraver
         System.setProperty(KubeUtils.ENTANDO_RESOURCE_ACTION, Action.ADDED.name());
         System.setProperty(KubeUtils.ENTANDO_RESOURCE_NAMESPACE, entandoApp.getMetadata().getNamespace());
         System.setProperty(KubeUtils.ENTANDO_RESOURCE_NAME, entandoApp.getMetadata().getName());
+        System.setProperty(EntandoOperatorConfigProperty.ENTANDO_REQUIRES_FILESYSTEM_GROUP_OVERRIDE.getJvmSystemProperty(), "true");
+
+    }
+
+    @AfterEach
+    public void removeJvmProps() {
+        System.getProperties().remove(EntandoOperatorConfigProperty.ENTANDO_REQUIRES_FILESYSTEM_GROUP_OVERRIDE.getJvmSystemProperty());
 
     }
 
     @Test
     public void testPersistentVolumeClaim() {
-        //Given I have an Entando App with a Wildfly server
+        //Given I have an Entando App with a JBoss EAP server
         EntandoApp newEntandoApp = entandoApp;
         //And that K8S is up and receiving PVC requests
         PersistentVolumeClaimStatus pvcStatus = new PersistentVolumeClaimStatus();
@@ -143,7 +152,7 @@ public class DeployEntandoServiceTest implements InProcessTestUtil, FluentTraver
 
     @Test
     public void testService() {
-        //Given I have an Entando App with a Wildfly server
+        //Given I have an Entando App with a JBoss EAP server
         EntandoApp newEntandoApp = entandoApp;
         //And that K8S is up and receiving Service requests
         ServiceStatus serviceStatus = new ServiceStatus();
@@ -177,7 +186,7 @@ public class DeployEntandoServiceTest implements InProcessTestUtil, FluentTraver
 
     @Test
     public void testIngress() {
-        //Given I have an Entando App with a Wildfly server
+        //Given I have an Entando App with a JBoss EAP server
         EntandoApp newEntandoApp = entandoApp;
         //And that K8S is up and receiving Ingress requests
         IngressStatus ingressStatus = new IngressStatus();
@@ -214,7 +223,7 @@ public class DeployEntandoServiceTest implements InProcessTestUtil, FluentTraver
     public void testDeployment() {
         //Given I use the 6.0.0 image version by default
         System.setProperty(EntandoOperatorConfigProperty.ENTANDO_DOCKER_IMAGE_VERSION_FALLBACK.getJvmSystemProperty(), "6.0.0");
-        //Given I have an Entando App with a Wildfly server
+        //Given I have an Entando App with a JBoss EAP server
         EntandoApp newEntandoApp = entandoApp;
         //And K8S is receiving Deployment requests
         DeploymentStatus deploymentStatus = new DeploymentStatus();
@@ -256,6 +265,8 @@ public class DeployEntandoServiceTest implements InProcessTestUtil, FluentTraver
         //And all volumes have been mapped
         verifyThatAllVolumesAreMapped(newEntandoApp, client, theServerDeployment);
         verifyThatAllVariablesAreMapped(newEntandoApp, client, theServerDeployment);
+
+        assertThat(theServerDeployment.getSpec().getTemplate().getSpec().getSecurityContext().getFsGroup(), is (185L));
 
     }
 
@@ -311,7 +322,7 @@ public class DeployEntandoServiceTest implements InProcessTestUtil, FluentTraver
         // container
         Container theEntandoServerContainer = theContainerNamed("server-container").on(theServerDeployment);
         //That points to the correct Docker image
-        assertThat(theEntandoServerContainer.getImage(), is("docker.io/entando/entando-de-app-wildfly:6.0.0"));
+        assertThat(theEntandoServerContainer.getImage(), is("docker.io/entando/entando-de-app-eap:6.0.0"));
         //Exposing a port named 'server-port' on 8080
         assertThat(thePortNamed(SERVER_PORT).on(theEntandoServerContainer).getContainerPort(), is(8080));
         assertThat(thePortNamed(SERVER_PORT).on(theEntandoServerContainer).getProtocol(), is(TCP));

--- a/src/test/java/org/entando/kubernetes/controller/app/inprocesstests/DeployEntandoServiceTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/app/inprocesstests/DeployEntandoServiceTest.java
@@ -266,7 +266,7 @@ public class DeployEntandoServiceTest implements InProcessTestUtil, FluentTraver
         verifyThatAllVolumesAreMapped(newEntandoApp, client, theServerDeployment);
         verifyThatAllVariablesAreMapped(newEntandoApp, client, theServerDeployment);
 
-        assertThat(theServerDeployment.getSpec().getTemplate().getSpec().getSecurityContext().getFsGroup(), is (185L));
+        assertThat(theServerDeployment.getSpec().getTemplate().getSpec().getSecurityContext().getFsGroup(), is(185L));
 
     }
 

--- a/src/test/java/org/entando/kubernetes/controller/app/inprocesstests/DeployEntandoWithEmbeddedDbTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/app/inprocesstests/DeployEntandoWithEmbeddedDbTest.java
@@ -31,6 +31,7 @@ import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.client.Watcher.Action;
 import io.quarkus.runtime.StartupEvent;
+import org.entando.kubernetes.controller.EntandoOperatorConfigProperty;
 import org.entando.kubernetes.controller.KubeUtils;
 import org.entando.kubernetes.controller.SimpleKeycloakClient;
 import org.entando.kubernetes.controller.app.EntandoAppController;
@@ -45,6 +46,7 @@ import org.entando.kubernetes.controller.test.support.FluentTraversals;
 import org.entando.kubernetes.model.DbmsVendor;
 import org.entando.kubernetes.model.app.EntandoApp;
 import org.entando.kubernetes.model.app.EntandoAppBuilder;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -76,11 +78,16 @@ public class DeployEntandoWithEmbeddedDbTest implements InProcessTestUtil, Fluen
         client.secrets().overwriteControllerSecret(buildInfrastructureSecret());
         entandoAppController = new EntandoAppController(client, keycloakClient);
         client.entandoResources().createOrPatchEntandoResource(entandoApp);
+        System.setProperty(EntandoOperatorConfigProperty.ENTANDO_REQUIRES_FILESYSTEM_GROUP_OVERRIDE.getJvmSystemProperty(),"true");
         System.setProperty(KubeUtils.ENTANDO_RESOURCE_ACTION, Action.ADDED.name());
         System.setProperty(KubeUtils.ENTANDO_RESOURCE_NAMESPACE, entandoApp.getMetadata().getNamespace());
         System.setProperty(KubeUtils.ENTANDO_RESOURCE_NAME, entandoApp.getMetadata().getName());
     }
+    @AfterEach
+    public void removeJvmProps(){
+        System.getProperties().remove(EntandoOperatorConfigProperty.ENTANDO_REQUIRES_FILESYSTEM_GROUP_OVERRIDE.getJvmSystemProperty());
 
+    }
     @Test
     public void testSecrets() {
         //Given I have created an EntandoApp with the spec.dbms property set to 'none'
@@ -148,7 +155,7 @@ public class DeployEntandoWithEmbeddedDbTest implements InProcessTestUtil, Fluen
                 is("/entando-data"));
         // And a PersistentVolumeClaim has been created for the derby database
         assertThat(this.client.persistentVolumeClaims().loadPersistentVolumeClaim(entandoApp, MY_APP + "-de-pvc"), not(nullValue()));
-
+        assertThat(entandoDeployment.getSpec().getTemplate().getSpec().getSecurityContext().getFsGroup(), is (1001L));
         verifyThatAllVolumesAreMapped(entandoApp, client, entandoDeployment);
     }
 

--- a/src/test/java/org/entando/kubernetes/controller/app/inprocesstests/DeployEntandoWithEmbeddedDbTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/app/inprocesstests/DeployEntandoWithEmbeddedDbTest.java
@@ -78,16 +78,18 @@ public class DeployEntandoWithEmbeddedDbTest implements InProcessTestUtil, Fluen
         client.secrets().overwriteControllerSecret(buildInfrastructureSecret());
         entandoAppController = new EntandoAppController(client, keycloakClient);
         client.entandoResources().createOrPatchEntandoResource(entandoApp);
-        System.setProperty(EntandoOperatorConfigProperty.ENTANDO_REQUIRES_FILESYSTEM_GROUP_OVERRIDE.getJvmSystemProperty(),"true");
+        System.setProperty(EntandoOperatorConfigProperty.ENTANDO_REQUIRES_FILESYSTEM_GROUP_OVERRIDE.getJvmSystemProperty(), "true");
         System.setProperty(KubeUtils.ENTANDO_RESOURCE_ACTION, Action.ADDED.name());
         System.setProperty(KubeUtils.ENTANDO_RESOURCE_NAMESPACE, entandoApp.getMetadata().getNamespace());
         System.setProperty(KubeUtils.ENTANDO_RESOURCE_NAME, entandoApp.getMetadata().getName());
     }
+
     @AfterEach
-    public void removeJvmProps(){
+    public void removeJvmProps() {
         System.getProperties().remove(EntandoOperatorConfigProperty.ENTANDO_REQUIRES_FILESYSTEM_GROUP_OVERRIDE.getJvmSystemProperty());
 
     }
+
     @Test
     public void testSecrets() {
         //Given I have created an EntandoApp with the spec.dbms property set to 'none'
@@ -155,7 +157,7 @@ public class DeployEntandoWithEmbeddedDbTest implements InProcessTestUtil, Fluen
                 is("/entando-data"));
         // And a PersistentVolumeClaim has been created for the derby database
         assertThat(this.client.persistentVolumeClaims().loadPersistentVolumeClaim(entandoApp, MY_APP + "-de-pvc"), not(nullValue()));
-        assertThat(entandoDeployment.getSpec().getTemplate().getSpec().getSecurityContext().getFsGroup(), is (1001L));
+        assertThat(entandoDeployment.getSpec().getTemplate().getSpec().getSecurityContext().getFsGroup(), is(1001L));
         verifyThatAllVolumesAreMapped(entandoApp, client, entandoDeployment);
     }
 


### PR DESCRIPTION
Ths PR brings in new features from entando-k8s-operator-common for ENG-669 and ENG-650
For ENG-669 we now allow implementations of the Deployable interface to specify the number ID in the operating system of the User/Group that should own persistent volume mappings.
In the case of the RedHat EAP image, the default user is 185
In the case of the  Wildfly image, the default user is 1001 
