### PR TITLE
Eng 529 db connection restore

### DIFF
--- a/src/main/java/org/entando/kubernetes/controller/app/EntandoAppDeployableContainer.java
+++ b/src/main/java/org/entando/kubernetes/controller/app/EntandoAppDeployableContainer.java
@@ -29,6 +29,7 @@ import org.entando.kubernetes.controller.spi.KeycloakAware;
 import org.entando.kubernetes.controller.spi.ParameterizableContainer;
 import org.entando.kubernetes.controller.spi.PersistentVolumeAware;
 import org.entando.kubernetes.controller.spi.TlsAware;
+import org.entando.kubernetes.model.DbmsVendor;
 import org.entando.kubernetes.model.EntandoDeploymentSpec;
 import org.entando.kubernetes.model.JeeServer;
 import org.entando.kubernetes.model.app.EntandoApp;
@@ -44,6 +45,7 @@ public class EntandoAppDeployableContainer extends EntandoDatabaseConsumingConta
     private final KeycloakConnectionConfig keycloakConnectionConfig;
 
     public EntandoAppDeployableContainer(EntandoApp entandoApp, KeycloakConnectionConfig keycloakConnectionConfig) {
+        super(entandoApp.getSpec().getDbms().orElse(DbmsVendor.EMBEDDED));
         this.entandoApp = entandoApp;
         this.keycloakConnectionConfig = keycloakConnectionConfig;
     }

--- a/src/main/java/org/entando/kubernetes/controller/app/EntandoDatabaseConsumingContainer.java
+++ b/src/main/java/org/entando/kubernetes/controller/app/EntandoDatabaseConsumingContainer.java
@@ -24,10 +24,10 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import org.entando.kubernetes.controller.KubeUtils;
 import org.entando.kubernetes.controller.database.DatabaseSchemaCreationResult;
-import org.entando.kubernetes.controller.database.DbmsVendorConfig;
 import org.entando.kubernetes.controller.spi.DatabasePopulator;
 import org.entando.kubernetes.controller.spi.DbAware;
 import org.entando.kubernetes.controller.spi.IngressingContainer;
+import org.entando.kubernetes.model.DbmsVendor;
 
 public abstract class EntandoDatabaseConsumingContainer implements DbAware, IngressingContainer {
 
@@ -36,6 +36,11 @@ public abstract class EntandoDatabaseConsumingContainer implements DbAware, Ingr
     private static final String PORTDB_PREFIX = "PORTDB_";
     private static final String SERVDB_PREFIX = "SERVDB_";
     private Map<String, DatabaseSchemaCreationResult> dbSchemas = new ConcurrentHashMap<>();
+    private DbmsVendor dbmsVendor;
+
+    public EntandoDatabaseConsumingContainer(DbmsVendor dbmsVendor) {
+        this.dbmsVendor = dbmsVendor;
+    }
 
     protected DatabasePopulator buildDatabasePopulator() {
         return new EntandoAppDatabasePopulator(this);
@@ -70,6 +75,10 @@ public abstract class EntandoDatabaseConsumingContainer implements DbAware, Ingr
                     KubeUtils.secretKeyRef(dbDeploymentResult.getSchemaSecretName(), KubeUtils.USERNAME_KEY)));
             vars.add(new EnvVar(varNamePrefix + "PASSWORD", null,
                     KubeUtils.secretKeyRef(dbDeploymentResult.getSchemaSecretName(), KubeUtils.PASSSWORD_KEY)));
+
+            JbossDatasourceValidation jbossDatasourceValidation = JbossDatasourceValidation.getValidConnectionCheckerClass(this.dbmsVendor);
+            vars.add(new EnvVar(varNamePrefix + "CONNECTION_CHECKER", jbossDatasourceValidation.getValidConnectionCheckerClassName(), null));
+            vars.add(new EnvVar(varNamePrefix + "EXCEPTION_SORTER", jbossDatasourceValidation.getExceptionSorterClassName(), null));
         }
 
     }
@@ -85,6 +94,10 @@ public abstract class EntandoDatabaseConsumingContainer implements DbAware, Ingr
         return Optional.of(buildDatabasePopulator());
     }
 
+
+    /**
+     * EntandoAppDatabasePopulator class
+     */
     public static class EntandoAppDatabasePopulator implements DatabasePopulator {
 
         private final EntandoDatabaseConsumingContainer entandoAppDeployableContainer;

--- a/src/main/java/org/entando/kubernetes/controller/app/EntandoDatabaseConsumingContainer.java
+++ b/src/main/java/org/entando/kubernetes/controller/app/EntandoDatabaseConsumingContainer.java
@@ -77,8 +77,10 @@ public abstract class EntandoDatabaseConsumingContainer implements DbAware, Ingr
                     KubeUtils.secretKeyRef(dbDeploymentResult.getSchemaSecretName(), KubeUtils.PASSSWORD_KEY)));
 
             JbossDatasourceValidation jbossDatasourceValidation = JbossDatasourceValidation.getValidConnectionCheckerClass(this.dbmsVendor);
-            vars.add(new EnvVar(varNamePrefix + "CONNECTION_CHECKER", jbossDatasourceValidation.getValidConnectionCheckerClassName(), null));
-            vars.add(new EnvVar(varNamePrefix + "EXCEPTION_SORTER", jbossDatasourceValidation.getExceptionSorterClassName(), null));
+            vars.add(new EnvVar(varNamePrefix + "CONNECTION_CHECKER", jbossDatasourceValidation.getValidConnectionCheckerClassName(),
+                    null));
+            vars.add(new EnvVar(varNamePrefix + "EXCEPTION_SORTER", jbossDatasourceValidation.getExceptionSorterClassName(),
+                    null));
         }
 
     }
@@ -96,7 +98,7 @@ public abstract class EntandoDatabaseConsumingContainer implements DbAware, Ingr
 
 
     /**
-     * EntandoAppDatabasePopulator class
+     * EntandoAppDatabasePopulator class.
      */
     public static class EntandoAppDatabasePopulator implements DatabasePopulator {
 

--- a/src/main/java/org/entando/kubernetes/controller/app/JbossDatasourceValidation.java
+++ b/src/main/java/org/entando/kubernetes/controller/app/JbossDatasourceValidation.java
@@ -26,7 +26,7 @@ public enum JbossDatasourceValidation {
 
     MYSQL("org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLValidConnectionChecker",
             "org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLExceptionSorter"),
-    POSTGRES("org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLValidConnectionChecker",
+    POSTGRESQL("org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLValidConnectionChecker",
             "org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLExceptionSorter"),
     ORACLE("org.jboss.jca.adapters.jdbc.extensions.oracle.OracleValidConnectionChecker",
             "org.jboss.jca.adapters.jdbc.extensions.oracle.OracleExceptionSorter"),
@@ -34,8 +34,16 @@ public enum JbossDatasourceValidation {
             "org.jboss.jca.adapters.jdbc.extensions.novendor.NullExceptionSorter");
 
 
-    private String validConnectionCheckerClassName;
-    private String exceptionSorterClassName;
+    /**
+     * contains full class name responsible to check for connection validity
+     */
+    private final String validConnectionCheckerClassName;
+
+    /**
+     * contains full class name responsible to sort db connection exception
+     */
+    private final String exceptionSorterClassName;
+
 
     JbossDatasourceValidation(String validConnectionCheckerClassName, String exceptionSorterClassName) {
         this.validConnectionCheckerClassName = validConnectionCheckerClassName;
@@ -66,7 +74,7 @@ public enum JbossDatasourceValidation {
                 return ORACLE;
 
             case POSTGRESQL:
-                return POSTGRES;
+                return POSTGRESQL;
 
             default:
                 return DEFAULT;

--- a/src/main/java/org/entando/kubernetes/controller/app/JbossDatasourceValidation.java
+++ b/src/main/java/org/entando/kubernetes/controller/app/JbossDatasourceValidation.java
@@ -14,10 +14,11 @@
  *
  */
 
-/**
- * contains the ValidConnectionChecker and ExceptionSorted class names
- */
 package org.entando.kubernetes.controller.app;
+
+/**
+ * contains the ValidConnectionChecker and ExceptionSorted class names.
+ */
 
 import java.util.Optional;
 import org.entando.kubernetes.model.DbmsVendor;
@@ -35,12 +36,12 @@ public enum JbossDatasourceValidation {
 
 
     /**
-     * contains full class name responsible to check for connection validity
+     * contains full class name responsible to check for connection validity.
      */
     private final String validConnectionCheckerClassName;
 
     /**
-     * contains full class name responsible to sort db connection exception
+     * contains full class name responsible to sort db connection exception.
      */
     private final String exceptionSorterClassName;
 
@@ -59,7 +60,7 @@ public enum JbossDatasourceValidation {
     }
 
     /**
-     * receives a DbmsVendor and returns the corresponing JbossDatasourceValidation
+     * receives a DbmsVendor and returns the corresponing JbossDatasourceValidation.
      * @param dbmsVendor the DbmsVendor on which switch
      * @return the corresponing JbossDatasourceValidation
      */

--- a/src/main/java/org/entando/kubernetes/controller/app/JbossDatasourceValidation.java
+++ b/src/main/java/org/entando/kubernetes/controller/app/JbossDatasourceValidation.java
@@ -1,0 +1,76 @@
+/*
+ *
+ * Copyright 2015-Present Entando Inc. (http://www.entando.com) All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ *  This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ */
+
+/**
+ * contains the ValidConnectionChecker and ExceptionSorted class names
+ */
+package org.entando.kubernetes.controller.app;
+
+import java.util.Optional;
+import org.entando.kubernetes.model.DbmsVendor;
+
+public enum JbossDatasourceValidation {
+
+    MYSQL("org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLValidConnectionChecker",
+            "org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLExceptionSorter"),
+    POSTGRES("org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLValidConnectionChecker",
+            "org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLExceptionSorter"),
+    ORACLE("org.jboss.jca.adapters.jdbc.extensions.oracle.OracleValidConnectionChecker",
+            "org.jboss.jca.adapters.jdbc.extensions.oracle.OracleExceptionSorter"),
+    DEFAULT("org.jboss.jca.adapters.jdbc.extensions.novendor.NullValidConnectionChecker",
+            "org.jboss.jca.adapters.jdbc.extensions.novendor.NullExceptionSorter");
+
+
+    private String validConnectionCheckerClassName;
+    private String exceptionSorterClassName;
+
+    JbossDatasourceValidation(String validConnectionCheckerClassName, String exceptionSorterClassName) {
+        this.validConnectionCheckerClassName = validConnectionCheckerClassName;
+        this.exceptionSorterClassName = exceptionSorterClassName;
+    }
+
+    public String getValidConnectionCheckerClassName() {
+        return validConnectionCheckerClassName;
+    }
+
+    public String getExceptionSorterClassName() {
+        return exceptionSorterClassName;
+    }
+
+    /**
+     * receives a DbmsVendor and returns the corresponing JbossDatasourceValidation
+     * @param dbmsVendor the DbmsVendor on which switch
+     * @return the corresponing JbossDatasourceValidation
+     */
+    public static JbossDatasourceValidation getValidConnectionCheckerClass(DbmsVendor dbmsVendor) {
+
+        switch (Optional.ofNullable(dbmsVendor).orElse(DbmsVendor.NONE)) {
+
+            case MYSQL:
+                return MYSQL;
+
+            case ORACLE:
+                return ORACLE;
+
+            case POSTGRESQL:
+                return POSTGRES;
+
+            default:
+                return DEFAULT;
+        }
+    }
+
+}

--- a/src/test/java/org/entando/kubernetes/controller/app/inprocesstests/DeployEntandoDbConsumerTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/app/inprocesstests/DeployEntandoDbConsumerTest.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import org.entando.kubernetes.controller.DeployCommand;
 import org.entando.kubernetes.controller.KubeUtils;
 import org.entando.kubernetes.controller.SimpleKeycloakClient;
+import org.entando.kubernetes.controller.app.testutils.EnvVarAssertionHelper;
 import org.entando.kubernetes.controller.common.KeycloakConnectionSecret;
 import org.entando.kubernetes.controller.database.DatabaseDeployable;
 import org.entando.kubernetes.controller.database.DatabaseServiceResult;
@@ -99,9 +100,11 @@ public class DeployEntandoDbConsumerTest implements InProcessTestUtil, FluentTra
         //And the Entando port and serv dbs have been populated
         Container dbPopulationJob = theInitContainerNamed(MY_APP + "-server-db-population-job").on(dbJob);
         assertThat(dbPopulationJob.getCommand().get(2), is("/entando-common/init-db-from-deployment.sh"));
-        assertThat(theVariableNamed("PORTDB_URL").on(dbPopulationJob),
-                is("jdbc:postgresql://" + MY_APP + "-db-service." + MY_APP_NAMESPACE + ".svc.cluster.local:5432/my_app_db"));
-        assertThat(theVariableNamed("SERVDB_URL").on(dbPopulationJob),
-                is("jdbc:postgresql://" + MY_APP + "-db-service." + MY_APP_NAMESPACE + ".svc.cluster.local:5432/my_app_db"));
+
+        //And per schema env vars are injected
+        EnvVarAssertionHelper.assertSchemaEnvironmentVariables(dbPopulationJob, "PORTDB_", this, "my-app-db-service", MY_APP_NAMESPACE,
+                DbmsVendor.POSTGRESQL.toString().toLowerCase(), "5432", "my_app_db");
+        EnvVarAssertionHelper.assertSchemaEnvironmentVariables(dbPopulationJob, "SERVDB_", this, "my-app-db-service", MY_APP_NAMESPACE,
+                DbmsVendor.POSTGRESQL.toString().toLowerCase(), "5432", "my_app_db");
     }
 }

--- a/src/test/java/org/entando/kubernetes/controller/app/inprocesstests/DeployEntandoDbConsumerTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/app/inprocesstests/DeployEntandoDbConsumerTest.java
@@ -103,8 +103,8 @@ public class DeployEntandoDbConsumerTest implements InProcessTestUtil, FluentTra
 
         //And per schema env vars are injected
         EnvVarAssertionHelper.assertSchemaEnvironmentVariables(dbPopulationJob, "PORTDB_", this, "my-app-db-service", MY_APP_NAMESPACE,
-                DbmsVendor.POSTGRESQL.toString().toLowerCase(), "5432", "my_app_db");
+                "postgresql", "5432", "my_app_db");
         EnvVarAssertionHelper.assertSchemaEnvironmentVariables(dbPopulationJob, "SERVDB_", this, "my-app-db-service", MY_APP_NAMESPACE,
-                DbmsVendor.POSTGRESQL.toString().toLowerCase(), "5432", "my_app_db");
+                "postgresql", "5432", "my_app_db");
     }
 }

--- a/src/test/java/org/entando/kubernetes/controller/app/inprocesstests/DeployEntandoServiceTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/app/inprocesstests/DeployEntandoServiceTest.java
@@ -340,10 +340,10 @@ public class DeployEntandoServiceTest implements InProcessTestUtil, FluentTraver
         //And per schema env vars are injected
         EnvVarAssertionHelper.assertSchemaEnvironmentVariables(theEntandoServerContainer, "PORTDB_",
                 this, MY_APP_DB_SERVICE, MY_APP_NAMESPACE,
-                DbmsVendor.MYSQL.toString().toLowerCase(), "3306", "my_app_portdb");
+                "mysql", "3306", "my_app_portdb");
         EnvVarAssertionHelper.assertSchemaEnvironmentVariables(theEntandoServerContainer, "SERVDB_",
                 this, MY_APP_DB_SERVICE, MY_APP_NAMESPACE,
-                DbmsVendor.MYSQL.toString().toLowerCase(), "3306", "my_app_servdb");
+                "mysql", "3306", "my_app_servdb");
 
         //But the db check on startup is disabled
         assertThat(theVariableNamed("DB_STARTUP_CHECK").on(theEntandoServerContainer), is("false"));

--- a/src/test/java/org/entando/kubernetes/controller/app/inprocesstests/DeployEntandoServiceTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/app/inprocesstests/DeployEntandoServiceTest.java
@@ -332,14 +332,10 @@ public class DeployEntandoServiceTest implements InProcessTestUtil, FluentTraver
                 is(MY_APP + "-portdb-secret"));
         assertThat(theVariableReferenceNamed("PORTDB_USERNAME").on(theEntandoServerContainer).getSecretKeyRef().getKey(),
                 is(KubeUtils.USERNAME_KEY));
-//        assertThat(theVariableNamed("PORTDB_URL").on(theEntandoServerContainer),
-//                is("jdbc:mysql://" + MY_APP_DB_SERVICE + "." + MY_APP_NAMESPACE + ".svc.cluster.local:3306/my_app_portdb"));
         assertThat(theVariableReferenceNamed("SERVDB_PASSWORD").on(theEntandoServerContainer).getSecretKeyRef().getName(),
                 is(MY_APP + "-servdb-secret"));
         assertThat(theVariableReferenceNamed("SERVDB_PASSWORD").on(theEntandoServerContainer).getSecretKeyRef().getKey(),
                 is(KubeUtils.PASSSWORD_KEY));
-//        assertThat(theVariableNamed("SERVDB_URL").on(theEntandoServerContainer),
-//                is("jdbc:mysql://" + MY_APP_DB_SERVICE + "." + MY_APP_NAMESPACE + ".svc.cluster.local:3306/my_app_servdb"));
 
         //And per schema env vars are injected
         EnvVarAssertionHelper.assertSchemaEnvironmentVariables(theEntandoServerContainer, "PORTDB_", this, MY_APP_DB_SERVICE, MY_APP_NAMESPACE,

--- a/src/test/java/org/entando/kubernetes/controller/app/inprocesstests/DeployEntandoServiceTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/app/inprocesstests/DeployEntandoServiceTest.java
@@ -338,9 +338,11 @@ public class DeployEntandoServiceTest implements InProcessTestUtil, FluentTraver
                 is(KubeUtils.PASSSWORD_KEY));
 
         //And per schema env vars are injected
-        EnvVarAssertionHelper.assertSchemaEnvironmentVariables(theEntandoServerContainer, "PORTDB_", this, MY_APP_DB_SERVICE, MY_APP_NAMESPACE,
+        EnvVarAssertionHelper.assertSchemaEnvironmentVariables(theEntandoServerContainer, "PORTDB_",
+                this, MY_APP_DB_SERVICE, MY_APP_NAMESPACE,
                 DbmsVendor.MYSQL.toString().toLowerCase(), "3306", "my_app_portdb");
-        EnvVarAssertionHelper.assertSchemaEnvironmentVariables(theEntandoServerContainer, "SERVDB_", this, MY_APP_DB_SERVICE, MY_APP_NAMESPACE,
+        EnvVarAssertionHelper.assertSchemaEnvironmentVariables(theEntandoServerContainer, "SERVDB_",
+                this, MY_APP_DB_SERVICE, MY_APP_NAMESPACE,
                 DbmsVendor.MYSQL.toString().toLowerCase(), "3306", "my_app_servdb");
 
         //But the db check on startup is disabled

--- a/src/test/java/org/entando/kubernetes/controller/app/inprocesstests/EntandoDbConsumingDeployable.java
+++ b/src/test/java/org/entando/kubernetes/controller/app/inprocesstests/EntandoDbConsumingDeployable.java
@@ -30,6 +30,7 @@ import org.entando.kubernetes.controller.database.DatabaseServiceResult;
 import org.entando.kubernetes.controller.spi.DbAwareDeployable;
 import org.entando.kubernetes.controller.spi.DeployableContainer;
 import org.entando.kubernetes.controller.spi.PublicIngressingDeployable;
+import org.entando.kubernetes.model.DbmsVendor;
 import org.entando.kubernetes.model.EntandoCustomResource;
 import org.entando.kubernetes.model.app.EntandoApp;
 
@@ -49,7 +50,7 @@ public class EntandoDbConsumingDeployable implements PublicIngressingDeployable<
         this.keycloakConnectionConfig = keycloakConnectionConfig;
         this.entandoApp = entandoApp;
         this.databaseServiceResult = databaseServiceResult;
-        this.containers = Arrays.asList(new EntandoDatabaseConsumingContainer() {
+        this.containers = Arrays.asList(new EntandoDatabaseConsumingContainer(entandoApp.getSpec().getDbms().orElse(DbmsVendor.EMBEDDED)) {
 
             @Override
             public void addDatabaseConnectionVariables(List<EnvVar> envVars) {
@@ -70,6 +71,8 @@ public class EntandoDbConsumingDeployable implements PublicIngressingDeployable<
             public int getPort() {
                 return 8080;
             }
+
+
         });
     }
 

--- a/src/test/java/org/entando/kubernetes/controller/app/testutils/EnvVarAssertionHelper.java
+++ b/src/test/java/org/entando/kubernetes/controller/app/testutils/EnvVarAssertionHelper.java
@@ -42,8 +42,8 @@ public class EnvVarAssertionHelper {
         assertThat(fluentTraversals.theVariableNamed(schemaPrefix + "URL").on(dbPopulationJob),
                 is("jdbc:" + dbVendor + "://" + dbService + "." + appNamespace + ".svc.cluster.local:" + port + "/" + dbName));
         assertThat(fluentTraversals.theVariableNamed(schemaPrefix + "CONNECTION_CHECKER").on(dbPopulationJob),
-                is(JbossDatasourceValidation.MYSQL.getValidConnectionCheckerClassName()));
+                is("org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLValidConnectionChecker"));
         assertThat(fluentTraversals.theVariableNamed(schemaPrefix + "EXCEPTION_SORTER").on(dbPopulationJob),
-                is(JbossDatasourceValidation.MYSQL.getExceptionSorterClassName()));
+                is("org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLExceptionSorter"));
     }
 }

--- a/src/test/java/org/entando/kubernetes/controller/app/testutils/EnvVarAssertionHelper.java
+++ b/src/test/java/org/entando/kubernetes/controller/app/testutils/EnvVarAssertionHelper.java
@@ -1,0 +1,45 @@
+/*
+ *
+ * Copyright 2015-Present Entando Inc. (http://www.entando.com) All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ *  This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ */
+
+package org.entando.kubernetes.controller.app.testutils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import io.fabric8.kubernetes.api.model.Container;
+import org.entando.kubernetes.controller.app.JbossDatasourceValidation;
+import org.entando.kubernetes.controller.test.support.FluentTraversals;
+
+public class EnvVarAssertionHelper {
+
+
+    /**
+     * does assertions on some environment variables
+     * @param dbPopulationJob the container on which do assertions
+     * @param schemaPrefix the schema prefix to prepend to the env vars to check
+     * @param
+     */
+    public static void assertSchemaEnvironmentVariables(Container dbPopulationJob, String schemaPrefix, FluentTraversals fluentTraversals,
+            String dbService, String appNamespace, String dbVendor, String port, String dbName) {
+
+        assertThat(fluentTraversals.theVariableNamed(schemaPrefix + "URL").on(dbPopulationJob),
+                is("jdbc:" + dbVendor + "://" + dbService + "." + appNamespace + ".svc.cluster.local:" + port + "/" + dbName));
+        assertThat(fluentTraversals.theVariableNamed(schemaPrefix + "CONNECTION_CHECKER").on(dbPopulationJob),
+                is(JbossDatasourceValidation.MYSQL.getValidConnectionCheckerClassName()));
+        assertThat(fluentTraversals.theVariableNamed(schemaPrefix + "EXCEPTION_SORTER").on(dbPopulationJob),
+                is(JbossDatasourceValidation.MYSQL.getExceptionSorterClassName()));
+    }
+}

--- a/src/test/java/org/entando/kubernetes/controller/app/testutils/EnvVarAssertionHelper.java
+++ b/src/test/java/org/entando/kubernetes/controller/app/testutils/EnvVarAssertionHelper.java
@@ -27,10 +27,14 @@ public class EnvVarAssertionHelper {
 
 
     /**
-     * does assertions on some environment variables
+     * does assertions on some environment variables.
      * @param dbPopulationJob the container on which do assertions
      * @param schemaPrefix the schema prefix to prepend to the env vars to check
-     * @param
+     * @param fluentTraversals the class implementing FluentTraversals interface from which get actual schema prefix
+     * @param dbService expected db service
+     * @param appNamespace expected db app namespace
+     * @param dbVendor expected db vendor name
+     * @param dbName expected db name
      */
     public static void assertSchemaEnvironmentVariables(Container dbPopulationJob, String schemaPrefix, FluentTraversals fluentTraversals,
             String dbService, String appNamespace, String dbVendor, String port, String dbName) {


### PR DESCRIPTION
Added some logic to populate 4 env vars useful for wildfly to reconnect automatically to the DB after connection lost.
They are used into entando-docker-base-images > entando-wildfly12-base

Env vars are:

PORTDB_CONNECTION_CHECKER
PORTDB_EXCEPTION_SORTER
SERVDB_CONNECTION_CHECKER
SERVDB_EXCEPTION_SORTER