### PR TITLE
ENG-787 modified the deployable containers to take spec.parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.entando</groupId>
         <artifactId>entando-quarkus-parent</artifactId>
-        <version>6.1.6</version>
+        <version>6.1.7</version>
     </parent>
     <version>6.1.0-SNAPSHOT</version>
     <artifactId>entando-k8s-app-controller</artifactId>

--- a/src/main/java/org/entando/kubernetes/controller/app/AppBuilderDeployableContainer.java
+++ b/src/main/java/org/entando/kubernetes/controller/app/AppBuilderDeployableContainer.java
@@ -21,10 +21,12 @@ import java.util.List;
 import java.util.Optional;
 import org.entando.kubernetes.controller.spi.DeployableContainer;
 import org.entando.kubernetes.controller.spi.IngressingContainer;
+import org.entando.kubernetes.controller.spi.ParameterizableContainer;
 import org.entando.kubernetes.controller.spi.TlsAware;
+import org.entando.kubernetes.model.EntandoDeploymentSpec;
 import org.entando.kubernetes.model.app.EntandoApp;
 
-public class AppBuilderDeployableContainer implements DeployableContainer, IngressingContainer, TlsAware {
+public class AppBuilderDeployableContainer implements DeployableContainer, IngressingContainer, TlsAware, ParameterizableContainer {
 
     private static final String ENTANDO_APP_BUILDER_IMAGE_NAME = "entando/app-builder";
     private final EntandoApp entandoApp;
@@ -71,5 +73,10 @@ public class AppBuilderDeployableContainer implements DeployableContainer, Ingre
     @Override
     public void addEnvironmentVariables(List<EnvVar> vars) {
         vars.add(new EnvVar("REACT_APP_DOMAIN", entandoApp.getSpec().getIngressPath().orElse("/entando-de-app"), null));
+    }
+
+    @Override
+    public EntandoDeploymentSpec getCustomResourceSpec() {
+        return this.entandoApp.getSpec();
     }
 }

--- a/src/main/java/org/entando/kubernetes/controller/app/ComponentManagerDeployableContainer.java
+++ b/src/main/java/org/entando/kubernetes/controller/app/ComponentManagerDeployableContainer.java
@@ -33,12 +33,14 @@ import org.entando.kubernetes.controller.common.InfrastructureConfig;
 import org.entando.kubernetes.controller.database.DatabaseSchemaCreationResult;
 import org.entando.kubernetes.controller.database.DbmsVendorConfig;
 import org.entando.kubernetes.controller.spi.DatabasePopulator;
+import org.entando.kubernetes.controller.spi.ParameterizableContainer;
 import org.entando.kubernetes.controller.spi.PersistentVolumeAware;
 import org.entando.kubernetes.controller.spi.SpringBootDeployableContainer;
+import org.entando.kubernetes.model.EntandoDeploymentSpec;
 import org.entando.kubernetes.model.app.EntandoApp;
 import org.entando.kubernetes.model.plugin.Permission;
 
-public class ComponentManagerDeployableContainer implements SpringBootDeployableContainer, PersistentVolumeAware {
+public class ComponentManagerDeployableContainer implements SpringBootDeployableContainer, PersistentVolumeAware, ParameterizableContainer {
 
     public static final String COMPONENT_MANAGER_QUALIFIER = "de";
     public static final String COMPONENT_MANAGER_IMAGE_NAME = "entando/entando-component-manager";
@@ -153,5 +155,10 @@ public class ComponentManagerDeployableContainer implements SpringBootDeployable
     @Override
     public String getVolumeMountPath() {
         return "/entando-data";
+    }
+
+    @Override
+    public EntandoDeploymentSpec getCustomResourceSpec() {
+        return this.entandoApp.getSpec();
     }
 }


### PR DESCRIPTION
The spec.parameters property is currently supported by all our custom resources. The idea was to use this as a "catch-all" for environment variables that the user may want to override or set at runtime. Unfortunately, spec.parameters was only applied to the Entando server container. This PR applies it to the AppBuilder container as well as the ComponentManager container.