### PR TITLE
ENG-3515 use networking.k8s.io/v1 api group instead of extensions/v1b…

### DIFF
--- a/Dockerfile.jvm
+++ b/Dockerfile.jvm
@@ -1,4 +1,4 @@
-FROM entando/entando-k8s-operator-common:6.3.20
+FROM entando/entando-k8s-operator-common:6.5.0-ENG-3515-PR-104
 ARG VERSION
 LABEL name="Entando K8S App Controller" \
       vendor="Entando" \

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.entando</groupId>
         <artifactId>entando-quarkus-parent</artifactId>
-        <version>6.3.21</version>
+        <version>6.5.0-ENG-3515-PR-26</version>
         <relativePath/>
     </parent>
     <version>6.5.0</version>
@@ -64,7 +64,7 @@
     <properties>
         <github.organization>entando-k8s</github.organization>
         <sonar.projectKey>${github.organization}_${project.artifactId}</sonar.projectKey>
-        <entando-k8s-operator-common.version>6.3.20</entando-k8s-operator-common.version>
+        <entando-k8s-operator-common.version>6.5.0-ENG-3515-PR-104</entando-k8s-operator-common.version>
         <skipLicenseDownload>true</skipLicenseDownload>
         <preDeploymentTestGroups>pre-deployment</preDeploymentTestGroups>
         <postDeploymentTestGroups>post-deployment</postDeploymentTestGroups>

--- a/src/main/java/org/entando/kubernetes/controller/app/AbstractEntandoAppDeployable.java
+++ b/src/main/java/org/entando/kubernetes/controller/app/AbstractEntandoAppDeployable.java
@@ -19,7 +19,7 @@ package org.entando.kubernetes.controller.app;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import java.util.Optional;
 import org.entando.kubernetes.controller.spi.common.NameUtils;
 import org.entando.kubernetes.controller.spi.container.KeycloakConnectionConfig;

--- a/src/main/java/org/entando/kubernetes/controller/app/EntandoAppDeploymentResult.java
+++ b/src/main/java/org/entando/kubernetes/controller/app/EntandoAppDeploymentResult.java
@@ -18,7 +18,7 @@ package org.entando.kubernetes.controller.app;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import org.entando.kubernetes.controller.spi.result.ExposedDeploymentResult;
 
 public class EntandoAppDeploymentResult extends ExposedDeploymentResult<EntandoAppDeploymentResult> {

--- a/src/test/java/org/entando/kubernetes/controller/app/inprocesstests/DeployEntandoServiceTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/app/inprocesstests/DeployEntandoServiceTest.java
@@ -40,8 +40,8 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceStatus;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentStatus;
-import io.fabric8.kubernetes.api.model.extensions.Ingress;
-import io.fabric8.kubernetes.api.model.extensions.IngressStatus;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressStatus;
 import io.fabric8.kubernetes.client.Watcher.Action;
 import io.quarkus.runtime.StartupEvent;
 import java.util.Collections;
@@ -151,7 +151,7 @@ class DeployEntandoServiceTest implements InProcessTestUtil, EnvVarAssertionHelp
         //And that K8S is up and receiving PVC requests
         PersistentVolumeClaimStatus pvcStatus = new PersistentVolumeClaimStatus();
         lenient().when(client.persistentVolumeClaims()
-                .loadPersistentVolumeClaim(eq(newEntandoApp), eq(MY_APP_SERVER_PVC)))
+                        .loadPersistentVolumeClaim(eq(newEntandoApp), eq(MY_APP_SERVER_PVC)))
                 .then(respondWithPersistentVolumeClaimStatus(pvcStatus));
         //When the EntandoAppController is notified that a new EntandoApp has been added
         entandoAppController.onStartup(new StartupEvent());
@@ -250,16 +250,16 @@ class DeployEntandoServiceTest implements InProcessTestUtil, EnvVarAssertionHelp
                 ingressArgumentCaptor.getValue().getMetadata().getName());
         assertThat(theIngress.getSpec().getRules().get(0).getHost(), is("myapp.192.168.0.100.nip.io"));
         // Then a K8S Ingress Path was created that reflects the webcontext of the entando-de-app
-        assertThat(theHttpPath(ENTANDO_DE_APP).on(theIngress).getBackend().getServicePort().getIntVal(), is(8080));
-        assertThat(theHttpPath(ENTANDO_DE_APP).on(theIngress).getBackend().getServiceName(), is(MY_APP_SERVER_SERVICE));
+        assertThat(theHttpPath(ENTANDO_DE_APP).on(theIngress).getBackend().getService().getPort().getNumber(), is(8080));
+        assertThat(theHttpPath(ENTANDO_DE_APP).on(theIngress).getBackend().getService().getName(), is(MY_APP_SERVER_SERVICE));
 
         // And a K8S Ingress Path was created that reflects the webcontext of the component-manager
-        assertThat(theHttpPath(DIGITAL_EXCHANGE).on(theIngress).getBackend().getServicePort().getIntVal(), is(8083));
-        assertThat(theHttpPath(DIGITAL_EXCHANGE).on(theIngress).getBackend().getServiceName(), is(MY_APP_COMPONENT_MANAGER_SERVICE));
+        assertThat(theHttpPath(DIGITAL_EXCHANGE).on(theIngress).getBackend().getService().getPort().getNumber(), is(8083));
+        assertThat(theHttpPath(DIGITAL_EXCHANGE).on(theIngress).getBackend().getService().getName(), is(MY_APP_COMPONENT_MANAGER_SERVICE));
 
         // And a K8S Ingress Path was created that reflects the webcontext of the appbuilder
-        assertThat(theHttpPath(APP_BUILDER).on(theIngress).getBackend().getServicePort().getIntVal(), is(8081));
-        assertThat(theHttpPath(APP_BUILDER).on(theIngress).getBackend().getServiceName(), is(MY_APP_APP_BUILDER_SERVICE));
+        assertThat(theHttpPath(APP_BUILDER).on(theIngress).getBackend().getService().getPort().getNumber(), is(8081));
+        assertThat(theHttpPath(APP_BUILDER).on(theIngress).getBackend().getService().getName(), is(MY_APP_APP_BUILDER_SERVICE));
         assertThat(theIngress.getMetadata().getAnnotations().get("nginx.ingress.kubernetes.io/proxy-body-size"), is("500m"));
 
         //And the Ingress state was reloaded from K8S


### PR DESCRIPTION
…eta1 for the created ingresses